### PR TITLE
Add specs checking that access is always provided to the raw API response

### DIFF
--- a/spec/duffel_api/services/airlines_service_spec.rb
+++ b/spec/duffel_api/services/airlines_service_spec.rb
@@ -53,7 +53,21 @@ describe DuffelAPI::Services::AirlinesService do
       end
 
       it "exposes the API response" do
-        expect(get_list_response.api_response).to be_a(DuffelAPI::APIResponse)
+        api_response = get_list_response.api_response
+
+        expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+        expect(api_response.headers).to eq(response_headers)
+        expect(api_response.raw_body).to be_a(String)
+        expect(api_response.parsed_body).to be_a(Hash)
+        expect(api_response.status_code).to eq(200)
+        expect(api_response.meta).to eq({
+          "after" => "g3QAAAACZAACaWRtAAAAGmFybF8wMDAwOVZNRTdEQUdpSmp3b21odjM1ZAAEbmFt" \
+                     "ZW0AAAARQWZyaXFpeWFoIEFpcndheXM=",
+          "before" => nil,
+          "limit" => 50,
+        })
+        expect(api_response.request_id).to eq(response_headers["x-request-id"])
       end
     end
 
@@ -118,6 +132,25 @@ describe DuffelAPI::Services::AirlinesService do
       expect(airline.id).to eq("arl_00009VME7DEWSV8v1yhJgK")
       expect(airline.name).to eq("12 North")
     end
+
+    it "exposes the API response on resources" do
+      records = client.airlines.all.to_a
+      api_response = records.first.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({
+        "after" => "g3QAAAACZAACaWRtAAAAGmFybF8wMDAwOVZNRTdEQUdpSmp3b21odjM1ZAAEbmFt" \
+                   "ZW0AAAARQWZyaXFpeWFoIEFpcndheXM=",
+        "before" => nil,
+        "limit" => 50,
+      })
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
+    end
   end
 
   describe "#get" do
@@ -146,6 +179,19 @@ describe DuffelAPI::Services::AirlinesService do
       expect(get_response.iata_code).to eq("12")
       expect(get_response.id).to eq("arl_00009VME7DEWSV8v1yhJgK")
       expect(get_response.name).to eq("12 North")
+    end
+
+    it "exposes the API response" do
+      api_response = get_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({})
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end
 end

--- a/spec/duffel_api/services/airports_service_spec.rb
+++ b/spec/duffel_api/services/airports_service_spec.rb
@@ -59,7 +59,21 @@ describe DuffelAPI::Services::AirportsService do
       end
 
       it "exposes the API response" do
-        expect(get_list_response.api_response).to be_a(DuffelAPI::APIResponse)
+        api_response = get_list_response.api_response
+
+        expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+        expect(api_response.headers).to eq(response_headers)
+        expect(api_response.raw_body).to be_a(String)
+        expect(api_response.parsed_body).to be_a(Hash)
+        expect(api_response.status_code).to eq(200)
+        expect(api_response.meta).to eq({
+          "after" => "g3QAAAACZAACaWRtAAAACmFycF9hZGxfYXVkAARuYW1lbQAAABBBZGVsYWlkZSBB" \
+                     "aXJwb3J0",
+          "before" => nil,
+          "limit" => 50,
+        })
+        expect(api_response.request_id).to eq(response_headers["x-request-id"])
       end
     end
 
@@ -130,6 +144,25 @@ describe DuffelAPI::Services::AirportsService do
       expect(airport.name).to eq("Aachen Merzbrück Airfield")
       expect(airport.time_zone).to eq("Europe/Berlin")
     end
+
+    it "exposes the API response" do
+      records = client.airports.all.to_a
+      api_response = records.first.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({
+        "after" => "g3QAAAACZAACaWRtAAAACmFycF9hZGxfYXVkAARuYW1lbQAAABBBZGVsYWlkZSBB" \
+                   "aXJwb3J0",
+        "before" => nil,
+        "limit" => 50,
+      })
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
+    end
   end
 
   describe "#get" do
@@ -165,6 +198,19 @@ describe DuffelAPI::Services::AirportsService do
       expect(get_response.longitude).to eq(45.304832)
       expect(get_response.name).to eq("Aden Adde International Airport")
       expect(get_response.time_zone).to eq("Africa/Mogadishu")
+    end
+
+    it "exposes the API response" do
+      api_response = get_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({})
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end
 end

--- a/spec/duffel_api/services/offer_requests_service_spec.rb
+++ b/spec/duffel_api/services/offer_requests_service_spec.rb
@@ -71,6 +71,19 @@ describe DuffelAPI::Services::OfferRequestsService do
       expect(offer_request.offers.length).to eq(68)
     end
 
+    it "exposes the API response" do
+      api_response = post_create_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({})
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
+    end
+
     context "asking for offers not to be returned using the `return_offers` parameter" do
       let!(:stub) do
         stub_request(:post, "https://api.duffel.com/air/offer_requests").
@@ -140,7 +153,29 @@ describe DuffelAPI::Services::OfferRequestsService do
       end
 
       it "exposes the API response" do
-        expect(get_list_response.api_response).to be_a(DuffelAPI::APIResponse)
+        api_response = get_list_response.api_response
+
+        expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+        expect(api_response.headers).to eq(response_headers)
+        expect(api_response.raw_body).to be_a(String)
+        expect(api_response.parsed_body).to be_a(Hash)
+        expect(api_response.status_code).to eq(200)
+        expect(api_response.meta).to eq({
+          "after" => "g3QAAAACZAACaWRtAAAAGm9ycV8wMDAwQUVhdzE" \
+                     "yY1Nucks2NndpblkwZAALaW5zZXJ0ZWRfYXR0AA" \
+                     "AADWQACl9fc3RydWN0X19kAA9FbGl4aXIuRGF0Z" \
+                     "VRpbWVkAAhjYWxlbmRhcmQAE0VsaXhpci5DYWxl" \
+                     "bmRhci5JU09kAANkYXlhFGQABGhvdXJhDGQAC21" \
+                     "pY3Jvc2Vjb25kaAJiAAqpwGEGZAAGbWludXRlYQ" \
+                     "tkAAVtb250aGEMZAAGc2Vjb25kYTRkAApzdGRfb" \
+                     "2Zmc2V0YQBkAAl0aW1lX3pvbmVtAAAAB0V0Yy9V" \
+                     "VENkAAp1dGNfb2Zmc2V0YQBkAAR5ZWFyYgAAB-V" \
+                     "kAAl6b25lX2FiYnJtAAAAA1VUQw==",
+          "before" => nil,
+          "limit" => 50,
+        })
+        expect(api_response.request_id).to eq(response_headers["x-request-id"])
       end
     end
 
@@ -215,6 +250,33 @@ describe DuffelAPI::Services::OfferRequestsService do
       expect(offer_request.created_at).to eq("2021-12-20T12:22:02.773536Z")
       expect(offer_request.cabin_class).to eq("economy")
     end
+
+    it "exposes the API response" do
+      records = client.offer_requests.all
+      api_response = records.first.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({
+        "after" => "g3QAAAACZAACaWRtAAAAGm9ycV8wMDAwQUVhdzE" \
+                   "yY1Nucks2NndpblkwZAALaW5zZXJ0ZWRfYXR0AA" \
+                   "AADWQACl9fc3RydWN0X19kAA9FbGl4aXIuRGF0Z" \
+                   "VRpbWVkAAhjYWxlbmRhcmQAE0VsaXhpci5DYWxl" \
+                   "bmRhci5JU09kAANkYXlhFGQABGhvdXJhDGQAC21" \
+                   "pY3Jvc2Vjb25kaAJiAAqpwGEGZAAGbWludXRlYQ" \
+                   "tkAAVtb250aGEMZAAGc2Vjb25kYTRkAApzdGRfb" \
+                   "2Zmc2V0YQBkAAl0aW1lX3pvbmVtAAAAB0V0Yy9V" \
+                   "VENkAAp1dGNfb2Zmc2V0YQBkAAR5ZWFyYgAAB-V" \
+                   "kAAl6b25lX2FiYnJtAAAAA1VUQw==",
+        "before" => nil,
+        "limit" => 50,
+      })
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
+    end
   end
 
   describe "#get" do
@@ -248,6 +310,19 @@ describe DuffelAPI::Services::OfferRequestsService do
       expect(offer_request.id).to eq("orq_0000AEaw0wBYAwGG9tNnm4")
       expect(offer_request.created_at).to eq("2021-12-20T12:11:51.573119Z")
       expect(offer_request.cabin_class).to eq("economy")
+    end
+
+    it "exposes the API response" do
+      api_response = get_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({})
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end
 end

--- a/spec/duffel_api/services/offers_service_spec.rb
+++ b/spec/duffel_api/services/offers_service_spec.rb
@@ -90,7 +90,21 @@ describe DuffelAPI::Services::OffersService do
     end
 
     it "exposes the API response" do
-      expect(get_list_response.api_response).to be_a(DuffelAPI::APIResponse)
+      api_response = get_list_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({
+        "after" => "g3QAAAABZAACaWRtAAAAGm9mZl8wMDAwQUVkR1J" \
+                   "ra2lUVHpOVHdiZGdj",
+        "before" => nil,
+        "limit" => 50,
+      })
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end
 
@@ -177,6 +191,26 @@ describe DuffelAPI::Services::OffersService do
       expect(offer.total_emissions_kg).to eq("312")
       expect(offer.updated_at).to eq("2021-12-21T15:10:13.263399Z")
     end
+
+    it "exposes the API response on the resources" do
+      records = client.offers.
+        all(params: { offer_request_id: "orq_0000AEdGRPso4CyykxEIsa" }).to_a
+      api_response = records.first.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({
+        "after" => "g3QAAAABZAACaWRtAAAAGm9mZl8wMDAwQUVkR1J" \
+                   "ra2lUVHpOVHdiZGdj",
+        "before" => nil,
+        "limit" => 50,
+      })
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
+    end
   end
 
   describe "#get" do
@@ -242,6 +276,19 @@ describe DuffelAPI::Services::OffersService do
       expect(offer.total_currency).to eq("GBP")
       expect(offer.total_emissions_kg).to eq("116")
       expect(offer.updated_at).to eq("2021-10-18T10:48:24.571463Z")
+    end
+
+    it "exposes the API response" do
+      api_response = get_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({})
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
 
     context "with parameters" do

--- a/spec/duffel_api/services/order_cancellations_service_spec.rb
+++ b/spec/duffel_api/services/order_cancellations_service_spec.rb
@@ -60,6 +60,19 @@ describe DuffelAPI::Services::OrderCancellationsService do
       expect(order_cancellation.refund_currency).to eq("GBP")
       expect(order_cancellation.refund_to).to eq("balance")
     end
+
+    it "exposes the API response" do
+      api_response = post_create_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({})
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
+    end
   end
 
   describe "#list" do
@@ -114,7 +127,29 @@ describe DuffelAPI::Services::OrderCancellationsService do
     end
 
     it "exposes the API response" do
-      expect(get_list_response.api_response).to be_a(DuffelAPI::APIResponse)
+      api_response = get_list_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({
+        "after" => "g3QAAAACZAACaWRtAAAAGm9yZV8wMDAwQThMNDhZT" \
+                   "VlYVGlnVmlLZFpnZAALaW5zZXJ0ZWRfYXR0AAAADW" \
+                   "QACl9fc3RydWN0X19kAA9FbGl4aXIuRGF0ZVRpbWV" \
+                   "kAAhjYWxlbmRhcmQAE0VsaXhpci5DYWxlbmRhci5J" \
+                   "U09kAANkYXlhEGQABGhvdXJhCWQAC21pY3Jvc2Vjb" \
+                   "25kaAJiAAP8J2EGZAAGbWludXRlYQ5kAAVtb250aG" \
+                   "EGZAAGc2Vjb25kYTVkAApzdGRfb2Zmc2V0YQBkAAl" \
+                   "0aW1lX3pvbmVtAAAAB0V0Yy9VVENkAAp1dGNfb2Zm" \
+                   "c2V0YQBkAAR5ZWFyYgAAB-VkAAl6b25lX2FiYnJtA" \
+                   "AAAA1VUQw==",
+        "before" => nil,
+        "limit" => 50,
+      })
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end
 
@@ -172,6 +207,33 @@ describe DuffelAPI::Services::OrderCancellationsService do
       expect(order_cancellation.refund_currency).to eq("GBP")
       expect(order_cancellation.refund_to).to eq("balance")
     end
+
+    it "exposes the API response on the resources" do
+      records = client.order_cancellations.all
+      api_response = records.first.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({
+        "after" => "g3QAAAACZAACaWRtAAAAGm9yZV8wMDAwQThMNDhZT" \
+                   "VlYVGlnVmlLZFpnZAALaW5zZXJ0ZWRfYXR0AAAADW" \
+                   "QACl9fc3RydWN0X19kAA9FbGl4aXIuRGF0ZVRpbWV" \
+                   "kAAhjYWxlbmRhcmQAE0VsaXhpci5DYWxlbmRhci5J" \
+                   "U09kAANkYXlhEGQABGhvdXJhCWQAC21pY3Jvc2Vjb" \
+                   "25kaAJiAAP8J2EGZAAGbWludXRlYQ5kAAVtb250aG" \
+                   "EGZAAGc2Vjb25kYTVkAApzdGRfb2Zmc2V0YQBkAAl" \
+                   "0aW1lX3pvbmVtAAAAB0V0Yy9VVENkAAp1dGNfb2Zm" \
+                   "c2V0YQBkAAR5ZWFyYgAAB-VkAAl6b25lX2FiYnJtA" \
+                   "AAAA1VUQw==",
+        "before" => nil,
+        "limit" => 50,
+      })
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
+    end
   end
 
   describe "#get" do
@@ -209,6 +271,19 @@ describe DuffelAPI::Services::OrderCancellationsService do
       expect(order_cancellation.refund_currency).to eq("GBP")
       expect(order_cancellation.refund_to).to eq("balance")
     end
+
+    it "exposes the API response" do
+      api_response = get_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({})
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
+    end
   end
 
   describe "#confirm" do
@@ -245,6 +320,19 @@ describe DuffelAPI::Services::OrderCancellationsService do
       expect(order_cancellation.refund_amount).to eq("177.80")
       expect(order_cancellation.refund_currency).to eq("GBP")
       expect(order_cancellation.refund_to).to eq("balance")
+    end
+
+    it "exposes the API response" do
+      api_response = confirm_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({})
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end
 end

--- a/spec/duffel_api/services/order_change_offers_service_spec.rb
+++ b/spec/duffel_api/services/order_change_offers_service_spec.rb
@@ -66,7 +66,21 @@ describe DuffelAPI::Services::OrderChangeOffersService do
     end
 
     it "exposes the API response" do
-      expect(get_list_response.api_response).to be_a(DuffelAPI::APIResponse)
+      api_response = get_list_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({
+        "after" => "g3QAAAABZAACaWRtAAAAGm9mZl8wMDAwQUVkR1Jra" \
+                   "2lUVHpOVHdiZGdj",
+        "before" => nil,
+        "limit" => 50,
+      })
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end
 
@@ -128,6 +142,26 @@ describe DuffelAPI::Services::OrderChangeOffersService do
       expect(order_change_offer.slices.length).to eq(2)
       expect(order_change_offer.updated_at).to eq("2021-12-21T16:51:06.650804Z")
     end
+
+    it "exposes the API response on the resources" do
+      records = client.order_change_offers.
+        all(params: { order_change_request_id: "ocr_0000AEdPRxCTitEvxq8Oum" })
+      api_response = records.first.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({
+        "after" => "g3QAAAABZAACaWRtAAAAGm9mZl8wMDAwQUVkR1Jra" \
+                   "2lUVHpOVHdiZGdj",
+        "before" => nil,
+        "limit" => 50,
+      })
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
+    end
   end
 
   describe "#get" do
@@ -168,6 +202,19 @@ describe DuffelAPI::Services::OrderChangeOffersService do
       expect(order_change_offer.refund_to).to eq("original_form_of_payment")
       expect(order_change_offer.slices.length).to eq(2)
       expect(order_change_offer.updated_at).to eq("2021-12-21T16:51:06.650804Z")
+    end
+
+    it "exposes the API response" do
+      api_response = get_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({})
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end
 end

--- a/spec/duffel_api/services/order_change_requests_service_spec.rb
+++ b/spec/duffel_api/services/order_change_requests_service_spec.rb
@@ -84,6 +84,19 @@ describe DuffelAPI::Services::OrderChangeRequestsService do
         ],
       })
     end
+
+    it "exposes the API response" do
+      api_response = post_create_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to be_nil
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
+    end
   end
 
   describe "#get" do
@@ -129,6 +142,19 @@ describe DuffelAPI::Services::OrderChangeRequestsService do
           },
         ],
       })
+    end
+
+    it "exposes the API response" do
+      api_response = get_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to be_nil
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end
 end

--- a/spec/duffel_api/services/order_changes_service_spec.rb
+++ b/spec/duffel_api/services/order_changes_service_spec.rb
@@ -65,6 +65,19 @@ describe DuffelAPI::Services::OrderChangesService do
       expect(order_change.refund_to).to be_nil
       expect(order_change.slices.length).to eq(2)
     end
+
+    it "exposes the API response" do
+      api_response = post_create_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to be_nil
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
+    end
   end
 
   describe "#get" do
@@ -106,6 +119,19 @@ describe DuffelAPI::Services::OrderChangesService do
       expect(order_change.penalty_currency).to be_nil
       expect(order_change.refund_to).to be_nil
       expect(order_change.slices.length).to eq(2)
+    end
+
+    it "exposes the API response" do
+      api_response = get_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to be_nil
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end
 
@@ -159,6 +185,19 @@ describe DuffelAPI::Services::OrderChangesService do
       expect(order_change.penalty_currency).to be_nil
       expect(order_change.refund_to).to be_nil
       expect(order_change.slices.length).to eq(2)
+    end
+
+    it "exposes the API response" do
+      api_response = confirm_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to be_nil
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end
 end

--- a/spec/duffel_api/services/orders_service_spec.rb
+++ b/spec/duffel_api/services/orders_service_spec.rb
@@ -114,10 +114,23 @@ describe DuffelAPI::Services::OrdersService do
       expect(order.total_amount).to eq("1016.15")
       expect(order.total_currency).to eq("GBP")
     end
+
+    it "exposes the API response" do
+      api_response = post_create_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({})
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
+    end
   end
 
   describe "#update" do
-    subject(:post_create_response) do
+    subject(:update_response) do
       client.orders.update("ord_0000AEdJFxag2IaNxbrlY1", params: params)
     end
 
@@ -145,12 +158,12 @@ describe DuffelAPI::Services::OrdersService do
     end
 
     it "makes the expected request to the Duffel API" do
-      post_create_response
+      update_response
       expect(stub).to have_been_requested
     end
 
     it "returns the updated resource" do
-      order = post_create_response
+      order = update_response
 
       expect(order).to be_a(DuffelAPI::Resources::Order)
 
@@ -195,6 +208,19 @@ describe DuffelAPI::Services::OrdersService do
       expect(order.tax_currency).to eq("GBP")
       expect(order.total_amount).to eq("1016.15")
       expect(order.total_currency).to eq("GBP")
+    end
+
+    it "exposes the API response" do
+      api_response = update_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({})
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end
 
@@ -280,7 +306,29 @@ describe DuffelAPI::Services::OrdersService do
       end
 
       it "exposes the API response" do
-        expect(get_list_response.api_response).to be_a(DuffelAPI::APIResponse)
+        api_response = get_list_response.api_response
+
+        expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+        expect(api_response.headers).to eq(response_headers)
+        expect(api_response.raw_body).to be_a(String)
+        expect(api_response.parsed_body).to be_a(Hash)
+        expect(api_response.status_code).to eq(200)
+        expect(api_response.meta).to eq({
+          "after" => "g3QAAAACZAACaWRtAAAAGm9yZF8wMDAwQUQ0MEZ" \
+                     "PQW1STHloRTNLWGo2ZAALaW5zZXJ0ZWRfYXR0AA" \
+                     "AADWQACl9fc3RydWN0X19kAA9FbGl4aXIuRGF0Z" \
+                     "VRpbWVkAAhjYWxlbmRhcmQAE0VsaXhpci5DYWxl" \
+                     "bmRhci5JU09kAANkYXlhBGQABGhvdXJhEWQAC21" \
+                     "pY3Jvc2Vjb25kaAJiAAA5HGEGZAAGbWludXRlYQ" \
+                     "FkAAVtb250aGELZAAGc2Vjb25kYStkAApzdGRfb" \
+                     "2Zmc2V0YQBkAAl0aW1lX3pvbmVtAAAAB0V0Yy9V" \
+                     "VENkAAp1dGNfb2Zmc2V0YQBkAAR5ZWFyYgAAB-V" \
+                     "kAAl6b25lX2FiYnJtAAAAA1VUQw==",
+          "before" => nil,
+          "limit" => 50,
+        })
+        expect(api_response.request_id).to eq(response_headers["x-request-id"])
       end
     end
 
@@ -390,6 +438,33 @@ describe DuffelAPI::Services::OrdersService do
       expect(order.total_amount).to eq("1016.15")
       expect(order.total_currency).to eq("GBP")
     end
+
+    it "exposes the API response on the resources" do
+      records = client.orders.all
+      api_response = records.first.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({
+        "after" => "g3QAAAACZAACaWRtAAAAGm9yZF8wMDAwQUQ0MEZ" \
+                   "PQW1STHloRTNLWGo2ZAALaW5zZXJ0ZWRfYXR0AA" \
+                   "AADWQACl9fc3RydWN0X19kAA9FbGl4aXIuRGF0Z" \
+                   "VRpbWVkAAhjYWxlbmRhcmQAE0VsaXhpci5DYWxl" \
+                   "bmRhci5JU09kAANkYXlhBGQABGhvdXJhEWQAC21" \
+                   "pY3Jvc2Vjb25kaAJiAAA5HGEGZAAGbWludXRlYQ" \
+                   "FkAAVtb250aGELZAAGc2Vjb25kYStkAApzdGRfb" \
+                   "2Zmc2V0YQBkAAl0aW1lX3pvbmVtAAAAB0V0Yy9V" \
+                   "VENkAAp1dGNfb2Zmc2V0YQBkAAR5ZWFyYgAAB-V" \
+                   "kAAl6b25lX2FiYnJtAAAAA1VUQw==",
+        "before" => nil,
+        "limit" => 50,
+      })
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
+    end
   end
 
   describe "#get" do
@@ -458,6 +533,19 @@ describe DuffelAPI::Services::OrdersService do
       expect(order.tax_currency).to eq("GBP")
       expect(order.total_amount).to eq("1016.15")
       expect(order.total_currency).to eq("GBP")
+    end
+
+    it "exposes the API response" do
+      api_response = get_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({})
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end
 end

--- a/spec/duffel_api/services/payment_intents_service_spec.rb
+++ b/spec/duffel_api/services/payment_intents_service_spec.rb
@@ -69,6 +69,19 @@ describe DuffelAPI::Services::PaymentIntentsService do
       expect(payment_intent.status).to eq("succeeded")
       expect(payment_intent.updated_at).to eq("2021-12-21T22:02:41.194906Z")
     end
+
+    it "exposes the API response" do
+      api_response = post_create_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({})
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
+    end
   end
 
   describe "#get" do
@@ -114,6 +127,19 @@ describe DuffelAPI::Services::PaymentIntentsService do
       expect(payment_intent.status).to eq("succeeded")
       expect(payment_intent.updated_at).to eq("2021-12-21T22:02:41.194906Z")
     end
+
+    it "exposes the API response" do
+      api_response = get_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({})
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
+    end
   end
 
   describe "#confirm" do
@@ -158,6 +184,19 @@ describe DuffelAPI::Services::PaymentIntentsService do
       expect(payment_intent.refunds).to eq([])
       expect(payment_intent.status).to eq("succeeded")
       expect(payment_intent.updated_at).to eq("2021-12-21T22:02:41.194906Z")
+    end
+
+    it "exposes the API response" do
+      api_response = confirm_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({})
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end
 end

--- a/spec/duffel_api/services/payments_service_spec.rb
+++ b/spec/duffel_api/services/payments_service_spec.rb
@@ -61,5 +61,18 @@ describe DuffelAPI::Services::PaymentsService do
       expect(payment.id).to eq("pay_0000AEdLTLasItzU4tTCS0")
       expect(payment.type).to eq("balance")
     end
+
+    it "exposes the API response" do
+      api_response = post_create_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to be_nil
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
+    end
   end
 end

--- a/spec/duffel_api/services/refunds_service_spec.rb
+++ b/spec/duffel_api/services/refunds_service_spec.rb
@@ -66,6 +66,19 @@ describe DuffelAPI::Services::RefundsService do
       expect(refund.status).to eq("succeeded")
       expect(refund.updated_at).to eq("2021-12-21T22:02:41.194906Z")
     end
+
+    it "exposes the API response" do
+      api_response = post_create_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({})
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
+    end
   end
 
   describe "#get" do
@@ -106,6 +119,19 @@ describe DuffelAPI::Services::RefundsService do
       expect(refund.payment_intent_id).to eq("pit_0000AEdrOAmsp2uXNytkrA")
       expect(refund.status).to eq("succeeded")
       expect(refund.updated_at).to eq("2021-12-21T22:02:41.194906Z")
+    end
+
+    it "exposes the API response" do
+      api_response = get_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to eq({})
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end
 end

--- a/spec/duffel_api/services/seat_maps_service_spec.rb
+++ b/spec/duffel_api/services/seat_maps_service_spec.rb
@@ -48,7 +48,16 @@ describe DuffelAPI::Services::SeatMapsService do
     end
 
     it "exposes the API response" do
-      expect(get_list_response.api_response).to be_a(DuffelAPI::APIResponse)
+      api_response = get_list_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to be_nil
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end
 end

--- a/spec/duffel_api/services/webhooks_service_spec.rb
+++ b/spec/duffel_api/services/webhooks_service_spec.rb
@@ -59,6 +59,19 @@ describe DuffelAPI::Services::WebhooksService do
       expect(webhook.secret).to eq("XRcsu65YS0sJ9T0ZUF3pwA==")
       expect(webhook.url).to eq("https://localhost:4567/webhooks")
     end
+
+    it "exposes the API response" do
+      api_response = post_create_response.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to be_nil
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
+    end
   end
 
   describe "#update" do
@@ -104,6 +117,19 @@ describe DuffelAPI::Services::WebhooksService do
       expect(webhook.live_mode).to be(false)
       expect(webhook.secret).to eq("XRcsu65YS0sJ9T0ZUF3pwA==")
       expect(webhook.url).to eq("https://localhost:4567/webhooks")
+    end
+
+    it "exposes the API response" do
+      api_response = patch_update.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.status_code).to eq(200)
+      expect(api_response.meta).to be_nil
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end
 


### PR DESCRIPTION
This commit adds specs across the whole of the library's surface area, checking that the library's public API provides access to the raw API response, a `DuffelAPI::APIResponse`.

This tests that for every method on every service.