### PR TITLE
Refactor `WebhooksService#ping` to provide access to the raw API response where successful

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ In general, these action methods return the record you've acted on.
 
 Watch out! There is one action in the API which doesn't return the record you've acted on.
 
-When you ping a webhook with `client.webhooks.ping("sev_0000AEdmUJKCvFK45qMFBg")`, it'll return `true` if successful, or otherwise it'll raise an error.
+When you ping a webhook with `client.webhooks.ping("sev_0000AEdmUJKCvFK45qMFBg")`, it'll return a `DuffelAPI::Services::WebhooksService::PingResult` if successful, or otherwise it'll raise an error.
 
 ### Handling errors
 

--- a/lib/duffel_api/response.rb
+++ b/lib/duffel_api/response.rb
@@ -22,6 +22,8 @@ module DuffelAPI
 
     # Returns the meta hash of the response
     def meta
+      return {} if parsed_body.nil?
+
       parsed_body.fetch("meta", {})
     rescue JSON::ParserError
       {}

--- a/lib/duffel_api/services/webhooks_service.rb
+++ b/lib/duffel_api/services/webhooks_service.rb
@@ -3,6 +3,20 @@
 module DuffelAPI
   module Services
     class WebhooksService < BaseService
+      class PingResult
+        attr_reader :api_response
+
+        def initialize(api_response)
+          @api_response = api_response
+        end
+
+        # If we return a `PingResult` rather than an error, then that means that the
+        # action was successful.
+        def succeeded
+          true
+        end
+      end
+
       def create(options = {})
         path = "/air/webhooks"
 
@@ -41,7 +55,6 @@ module DuffelAPI
         Resources::Webhook.new(unenvelope_body(response.parsed_body), response)
       end
 
-      # rubocop:disable Metrics/AbcSize
       def ping(id, options = {})
         path = substitute_url_pattern("/air/webhooks/:id/actions/ping", "id" => id)
 
@@ -55,18 +68,16 @@ module DuffelAPI
           # Response doesn't raise any errors until #body is called
           response.tap(&:raw_body)
         end
-
-        return if response.raw_body.nil?
-
-        Resources::Webhook.new(unenvelope_body(response.parsed_body), response)
       rescue DuffelAPI::Errors::Error => e
+        # We expect this API call to *ALWAYS* lead to an error being raised since
+        # it returns a non-JSON 204 response even if it's successful. We just catch
+        # that and bubble it up in a nicer way.
         if e.api_response.status_code == 204
-          true
+          PingResult.new(e.api_response)
         else
           raise e
         end
       end
-      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/spec/duffel_api/response_spec.rb
+++ b/spec/duffel_api/response_spec.rb
@@ -99,5 +99,13 @@ describe DuffelAPI::Response do
         expect(response.meta).to eq({})
       end
     end
+
+    context "with an empty response" do
+      let(:response_body) { "" }
+
+      it "returns an empty hash" do
+        expect(response.meta).to eq({})
+      end
+    end
   end
 end

--- a/spec/duffel_api/services/webhooks_service_spec.rb
+++ b/spec/duffel_api/services/webhooks_service_spec.rb
@@ -130,8 +130,22 @@ describe DuffelAPI::Services::WebhooksService do
       expect(stub).to have_been_requested
     end
 
-    it "returns true if the ping was successful" do
-      expect(ping_webhook).to be(true)
+    it "returns a PingResult if the ping was successful" do
+      expect(ping_webhook).to be_a(described_class::PingResult)
+      expect(ping_webhook.succeeded).to be(true)
+    end
+
+    it "exposes the API response on the PingResult" do
+      api_response = ping_webhook.api_response
+
+      expect(api_response).to be_a(DuffelAPI::APIResponse)
+
+      expect(api_response.headers).to eq(response_headers)
+      expect(api_response.raw_body).to be_a(String)
+      expect(api_response.parsed_body).to be_nil
+      expect(api_response.status_code).to eq(204)
+      expect(api_response.meta).to eq({})
+      expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
 
     context "when the ping fails" do


### PR DESCRIPTION
The "Ping a webhook" action in the Duffel API is unlike any other action - it returns a `204 No Content` response if successful. This unsurprisingly means it ends up being a bit of an exception in our code!

Right now, it returns `true` if the ping was successful or otherwise raises an error. This means that you can't get access to the raw API response in the success case - which is available for all other actions (see #5).

This changes `#ping` to return an instance of a new class called `PingResult` - it conforms to the API of other results in the
library thanks to its `#api_response` public method. It also exposes a `#succeeded` method, which returns `true`.

Failure cases continue to raise an error.