### PR TITLE
Use the lowest-powered available machine type in Circle for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
         type: string
     docker:
       - image: << parameters.ruby-image >>
+    resource_class: small
     steps:
       - checkout
       - run:
@@ -23,6 +24,7 @@ jobs:
   coverage:
     docker:
       - image: cimg/ruby:3.0
+    resource_class: small
     environment:
       COVERAGE: true
     steps:


### PR DESCRIPTION
The continuous integration for the library should be quick and low-effort to run, so this switches to using the lowest-powered available machine type for them, `small`.