### PR TITLE
Rationalise the interface of `DuffelAPI::APIResponse`

### DIFF
--- a/lib/duffel_api/api_response.rb
+++ b/lib/duffel_api/api_response.rb
@@ -10,10 +10,8 @@ module DuffelAPI
     end
 
     def_delegator :@response, :headers
-    def_delegator :@response, :raw_body
-    def_delegator :@response, :parsed_body
+    def_delegator :@response, :raw_body, :body
     def_delegator :@response, :status_code
-    def_delegator :@response, :meta
     def_delegator :@response, :request_id
   end
 end

--- a/lib/duffel_api/list_response.rb
+++ b/lib/duffel_api/list_response.rb
@@ -9,7 +9,7 @@ module DuffelAPI
       @resource_class = options.fetch(:resource_class)
       @unenveloped_body = options.fetch(:unenveloped_body)
 
-      @records = @unenveloped_body.map { |item| @resource_class.new(item, api_response) }
+      @records = @unenveloped_body.map { |item| @resource_class.new(item, @response) }
     end
 
     def api_response

--- a/spec/duffel_api/api_response_spec.rb
+++ b/spec/duffel_api/api_response_spec.rb
@@ -29,9 +29,7 @@ describe DuffelAPI::APIResponse do
 
     its(:status_code) { is_expected.to eq(200) }
     its(:headers) { is_expected.to eq(response_headers) }
-    its(:parsed_body) { is_expected.to eq("test" => true) }
-    its(:raw_body) { is_expected.to eq("{\"test\":true}") }
-    its(:meta) { is_expected.to eq({}) }
+    its(:body) { is_expected.to eq("{\"test\":true}") }
     its(:request_id) { is_expected.to eq("FsJz79144I4JjDwAA6TB") }
   end
 end

--- a/spec/duffel_api/middlewares/raise_duffel_errors_spec.rb
+++ b/spec/duffel_api/middlewares/raise_duffel_errors_spec.rb
@@ -34,10 +34,8 @@ describe DuffelAPI::Middlewares::RaiseDuffelErrors do
       expect(e.api_response).to be_a(DuffelAPI::APIResponse)
 
       expect(e.api_response.headers).to eq({ "content-type" => "text/html" })
-      expect(e.api_response.raw_body).to eq(body)
-      expect { e.api_response.parsed_body }.to raise_error(JSON::ParserError)
+      expect(e.api_response.body).to eq(body)
       expect(e.api_response.status_code).to eq(514)
-      expect(e.api_response.meta).to eq({})
     end
   end
 
@@ -56,10 +54,8 @@ describe DuffelAPI::Middlewares::RaiseDuffelErrors do
       expect(e.api_response).to be_a(DuffelAPI::APIResponse)
 
       expect(e.api_response.headers).to eq({ "content-type" => "application/json" })
-      expect(e.api_response.raw_body).to eq(body)
-      expect(e.api_response.parsed_body).to eq(JSON.parse(body))
+      expect(e.api_response.body).to eq(body)
       expect(e.api_response.status_code).to eq(503)
-      expect(e.api_response.meta).to eq({})
     end
   end
 
@@ -88,13 +84,8 @@ describe DuffelAPI::Middlewares::RaiseDuffelErrors do
         expect(e.api_response).to be_a(DuffelAPI::APIResponse)
 
         expect(e.api_response.headers).to eq({ "content-type" => "application/json" })
-        expect(e.api_response.raw_body).to eq(body)
-        expect(e.api_response.parsed_body).to eq(JSON.parse(body))
+        expect(e.api_response.body).to eq(body)
         expect(e.api_response.status_code).to eq(400)
-        expect(e.api_response.meta).to eq({
-          "request_id" => "FsJ5mIzW3k3Hfy0AAoKC",
-          "status" => 400,
-        })
       end
     end
 

--- a/spec/duffel_api/services/aircraft_service_spec.rb
+++ b/spec/duffel_api/services/aircraft_service_spec.rb
@@ -58,15 +58,8 @@ describe DuffelAPI::Services::AircraftService do
         expect(api_response).to be_a(DuffelAPI::APIResponse)
 
         expect(api_response.headers).to eq(response_headers)
-        expect(api_response.raw_body).to be_a(String)
-        expect(api_response.parsed_body).to be_a(Hash)
+        expect(api_response.body).to be_a(String)
         expect(api_response.status_code).to eq(200)
-        expect(api_response.meta).to eq({
-          "after" => "g3QAAAACZAACaWRtAAAAGmFyY18wMDAwOVZNRjhBZ3BWNXNkTzB4WEIwZAAEbmFt" \
-                     "ZW0AAAAPQWlyYnVzIEEzNDAtNTAw",
-          "before" => nil,
-          "limit" => 50,
-        })
         expect(api_response.request_id).to eq(response_headers["x-request-id"])
       end
     end
@@ -140,15 +133,8 @@ describe DuffelAPI::Services::AircraftService do
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.raw_body).to be_a(String)
-      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.body).to be_a(String)
       expect(api_response.status_code).to eq(200)
-      expect(api_response.meta).to eq({
-        "after" => "g3QAAAACZAACaWRtAAAAGmFyY18wMDAwOVZNRjhBZ3BWNXNkTzB4WEIwZAAEbmFt" \
-                   "ZW0AAAAPQWlyYnVzIEEzNDAtNTAw",
-        "before" => nil,
-        "limit" => 50,
-      })
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end
@@ -187,10 +173,8 @@ describe DuffelAPI::Services::AircraftService do
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.raw_body).to be_a(String)
-      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.body).to be_a(String)
       expect(api_response.status_code).to eq(200)
-      expect(api_response.meta).to eq({})
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end

--- a/spec/duffel_api/services/offer_passengers_service_spec.rb
+++ b/spec/duffel_api/services/offer_passengers_service_spec.rb
@@ -78,10 +78,8 @@ describe DuffelAPI::Services::OfferPassengersService do
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.raw_body).to be_a(String)
-      expect(api_response.parsed_body).to be_a(Hash)
+      expect(api_response.body).to be_a(String)
       expect(api_response.status_code).to eq(200)
-      expect(api_response.meta).to eq({})
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
     end
   end


### PR DESCRIPTION
This commit rationalises the public interface of `DuffelAPI::APIResponse` which we use to expose "raw API responses" across the library (i.e. provide access to the status code, body, headers and request ID).

It has a few extra public methods at the moment that aren't really necessarily and I'd prefer to keep it small and *tight*. We can always add more, but it's hard to take away!

Note that `APIResponse` is different to `Response` which is the representation of a raw API response used internally inside the library.