### PR TITLE
Fix broken specs

### DIFF
--- a/spec/duffel_api/services/aircraft_service_spec.rb
+++ b/spec/duffel_api/services/aircraft_service_spec.rb
@@ -57,10 +57,10 @@ describe DuffelAPI::Services::AircraftService do
 
         expect(api_response).to be_a(DuffelAPI::APIResponse)
 
-        expect(api_response.headers).to eq(response_headers)
         expect(api_response.body).to be_a(String)
-        expect(api_response.status_code).to eq(200)
+        expect(api_response.headers).to eq(response_headers)
         expect(api_response.request_id).to eq(response_headers["x-request-id"])
+        expect(api_response.status_code).to eq(200)
       end
     end
 
@@ -132,10 +132,10 @@ describe DuffelAPI::Services::AircraftService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
-      expect(api_response.headers).to eq(response_headers)
       expect(api_response.body).to be_a(String)
-      expect(api_response.status_code).to eq(200)
+      expect(api_response.headers).to eq(response_headers)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -172,10 +172,10 @@ describe DuffelAPI::Services::AircraftService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
-      expect(api_response.headers).to eq(response_headers)
       expect(api_response.body).to be_a(String)
-      expect(api_response.status_code).to eq(200)
+      expect(api_response.headers).to eq(response_headers)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 end

--- a/spec/duffel_api/services/airlines_service_spec.rb
+++ b/spec/duffel_api/services/airlines_service_spec.rb
@@ -57,9 +57,10 @@ describe DuffelAPI::Services::AirlinesService do
 
         expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+        expect(api_response.body).to be_a(String)
         expect(api_response.headers).to eq(response_headers)
-        expect(api_response.status_code).to eq(200)
         expect(api_response.request_id).to eq(response_headers["x-request-id"])
+        expect(api_response.status_code).to eq(200)
       end
     end
 
@@ -131,9 +132,10 @@ describe DuffelAPI::Services::AirlinesService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -170,9 +172,10 @@ describe DuffelAPI::Services::AirlinesService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 end

--- a/spec/duffel_api/services/airports_service_spec.rb
+++ b/spec/duffel_api/services/airports_service_spec.rb
@@ -63,9 +63,10 @@ describe DuffelAPI::Services::AirportsService do
 
         expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+        expect(api_response.body).to be_a(String)
         expect(api_response.headers).to eq(response_headers)
-        expect(api_response.status_code).to eq(200)
         expect(api_response.request_id).to eq(response_headers["x-request-id"])
+        expect(api_response.status_code).to eq(200)
       end
     end
 
@@ -143,9 +144,10 @@ describe DuffelAPI::Services::AirportsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -189,9 +191,10 @@ describe DuffelAPI::Services::AirportsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 end

--- a/spec/duffel_api/services/offer_passengers_service_spec.rb
+++ b/spec/duffel_api/services/offer_passengers_service_spec.rb
@@ -77,10 +77,10 @@ describe DuffelAPI::Services::OfferPassengersService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
-      expect(api_response.headers).to eq(response_headers)
       expect(api_response.body).to be_a(String)
-      expect(api_response.status_code).to eq(200)
+      expect(api_response.headers).to eq(response_headers)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 end

--- a/spec/duffel_api/services/offer_requests_service_spec.rb
+++ b/spec/duffel_api/services/offer_requests_service_spec.rb
@@ -76,9 +76,10 @@ describe DuffelAPI::Services::OfferRequestsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
 
     context "asking for offers not to be returned using the `return_offers` parameter" do
@@ -154,9 +155,10 @@ describe DuffelAPI::Services::OfferRequestsService do
 
         expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+        expect(api_response.body).to be_a(String)
         expect(api_response.headers).to eq(response_headers)
-        expect(api_response.status_code).to eq(200)
         expect(api_response.request_id).to eq(response_headers["x-request-id"])
+        expect(api_response.status_code).to eq(200)
       end
     end
 
@@ -238,9 +240,10 @@ describe DuffelAPI::Services::OfferRequestsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -282,9 +285,10 @@ describe DuffelAPI::Services::OfferRequestsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 end

--- a/spec/duffel_api/services/offers_service_spec.rb
+++ b/spec/duffel_api/services/offers_service_spec.rb
@@ -94,9 +94,10 @@ describe DuffelAPI::Services::OffersService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -191,9 +192,10 @@ describe DuffelAPI::Services::OffersService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -267,9 +269,10 @@ describe DuffelAPI::Services::OffersService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
 
     context "with parameters" do

--- a/spec/duffel_api/services/order_cancellations_service_spec.rb
+++ b/spec/duffel_api/services/order_cancellations_service_spec.rb
@@ -66,9 +66,10 @@ describe DuffelAPI::Services::OrderCancellationsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -128,9 +129,10 @@ describe DuffelAPI::Services::OrderCancellationsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -195,9 +197,10 @@ describe DuffelAPI::Services::OrderCancellationsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -242,9 +245,10 @@ describe DuffelAPI::Services::OrderCancellationsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -289,9 +293,10 @@ describe DuffelAPI::Services::OrderCancellationsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 end

--- a/spec/duffel_api/services/order_change_offers_service_spec.rb
+++ b/spec/duffel_api/services/order_change_offers_service_spec.rb
@@ -71,9 +71,10 @@ describe DuffelAPI::Services::OrderChangeOffersService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -144,9 +145,10 @@ describe DuffelAPI::Services::OrderChangeOffersService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -196,9 +198,10 @@ describe DuffelAPI::Services::OrderChangeOffersService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 end

--- a/spec/duffel_api/services/order_change_requests_service_spec.rb
+++ b/spec/duffel_api/services/order_change_requests_service_spec.rb
@@ -92,9 +92,10 @@ describe DuffelAPI::Services::OrderChangeRequestsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -150,9 +151,10 @@ describe DuffelAPI::Services::OrderChangeRequestsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 end

--- a/spec/duffel_api/services/order_changes_service_spec.rb
+++ b/spec/duffel_api/services/order_changes_service_spec.rb
@@ -71,9 +71,10 @@ describe DuffelAPI::Services::OrderChangesService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -123,9 +124,10 @@ describe DuffelAPI::Services::OrderChangesService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -186,9 +188,10 @@ describe DuffelAPI::Services::OrderChangesService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 end

--- a/spec/duffel_api/services/orders_service_spec.rb
+++ b/spec/duffel_api/services/orders_service_spec.rb
@@ -120,9 +120,10 @@ describe DuffelAPI::Services::OrdersService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -212,9 +213,10 @@ describe DuffelAPI::Services::OrdersService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -304,9 +306,10 @@ describe DuffelAPI::Services::OrdersService do
 
         expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+        expect(api_response.body).to be_a(String)
         expect(api_response.headers).to eq(response_headers)
-        expect(api_response.status_code).to eq(200)
         expect(api_response.request_id).to eq(response_headers["x-request-id"])
+        expect(api_response.status_code).to eq(200)
       end
     end
 
@@ -423,9 +426,10 @@ describe DuffelAPI::Services::OrdersService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -502,9 +506,10 @@ describe DuffelAPI::Services::OrdersService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 end

--- a/spec/duffel_api/services/payment_intents_service_spec.rb
+++ b/spec/duffel_api/services/payment_intents_service_spec.rb
@@ -75,9 +75,10 @@ describe DuffelAPI::Services::PaymentIntentsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -130,9 +131,10 @@ describe DuffelAPI::Services::PaymentIntentsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -185,9 +187,10 @@ describe DuffelAPI::Services::PaymentIntentsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 end

--- a/spec/duffel_api/services/payments_service_spec.rb
+++ b/spec/duffel_api/services/payments_service_spec.rb
@@ -67,9 +67,10 @@ describe DuffelAPI::Services::PaymentsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 end

--- a/spec/duffel_api/services/refunds_service_spec.rb
+++ b/spec/duffel_api/services/refunds_service_spec.rb
@@ -72,9 +72,10 @@ describe DuffelAPI::Services::RefundsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -123,9 +124,10 @@ describe DuffelAPI::Services::RefundsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 end

--- a/spec/duffel_api/services/seat_maps_service_spec.rb
+++ b/spec/duffel_api/services/seat_maps_service_spec.rb
@@ -52,9 +52,10 @@ describe DuffelAPI::Services::SeatMapsService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 end

--- a/spec/duffel_api/services/webhooks_service_spec.rb
+++ b/spec/duffel_api/services/webhooks_service_spec.rb
@@ -65,9 +65,10 @@ describe DuffelAPI::Services::WebhooksService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -121,9 +122,10 @@ describe DuffelAPI::Services::WebhooksService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(200)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(200)
     end
   end
 
@@ -160,9 +162,10 @@ describe DuffelAPI::Services::WebhooksService do
 
       expect(api_response).to be_a(DuffelAPI::APIResponse)
 
+      expect(api_response.body).to be_a(String)
       expect(api_response.headers).to eq(response_headers)
-      expect(api_response.status_code).to eq(204)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
+      expect(api_response.status_code).to eq(204)
     end
 
     context "when the ping fails" do


### PR DESCRIPTION
💁 Unfortunately the changes made to `DuffelAPI::APIResponse` in https://github.com/duffelhq/duffel-api-ruby/pull/11 broke these parts of the test suite. These changes remove those deprecated instance attributes.