### PR TITLE
Use BigDecimal in examples for accurate pricing arithmetic

### DIFF
--- a/examples/book_with_extra_baggage.rb
+++ b/examples/book_with_extra_baggage.rb
@@ -53,7 +53,7 @@ puts "Adding #{available_baggage['metadata']['maximum_weight_kg']}kg extra bagga
 
 total_amount = (
   BigDecimal(priced_offer.total_amount) + BigDecimal(available_baggage["total_amount"])
-).to_f.to_s
+).to_s("F")
 
 order = client.orders.create(params: {
   selected_offers: [priced_offer.id],

--- a/examples/book_with_extra_baggage.rb
+++ b/examples/book_with_extra_baggage.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "duffel_api"
+require "bigdecimal"
 
 client = DuffelAPI::Client.new(
   access_token: ENV["DUFFEL_ACCESS_TOKEN"],
@@ -50,8 +51,9 @@ puts "Adding #{available_baggage['metadata']['maximum_weight_kg']}kg extra bagga
      "#{available_baggage['total_amount']} " \
      "#{available_baggage['total_currency']}"
 
-total_amount = priced_offer.total_amount.to_f +
-  available_baggage["total_amount"].to_f
+total_amount = (
+  BigDecimal(priced_offer.total_amount) + BigDecimal(available_baggage["total_amount"])
+).to_f.to_s
 
 order = client.orders.create(params: {
   selected_offers: [priced_offer.id],

--- a/examples/book_with_seat.rb
+++ b/examples/book_with_seat.rb
@@ -59,7 +59,8 @@ puts "Adding seat #{available_seat['designator']} costing " \
      "#{available_seat_service['total_currency']}"
 
 total_amount = (
-  BigDecimal(priced_offer.total_amount) + BigDecimal(available_seat_service["total_amount"])
+  BigDecimal(priced_offer.total_amount) +
+  BigDecimal(available_seat_service["total_amount"])
 ).to_f.to_s
 
 order = client.orders.create(params: {

--- a/examples/book_with_seat.rb
+++ b/examples/book_with_seat.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "duffel_api"
+require "bigdecimal"
 
 client = DuffelAPI::Client.new(
   access_token: ENV["DUFFEL_ACCESS_TOKEN"],
@@ -57,8 +58,9 @@ puts "Adding seat #{available_seat['designator']} costing " \
      "#{available_seat_service['total_amount']} " \
      "#{available_seat_service['total_currency']}"
 
-total_amount = priced_offer.total_amount.to_f +
-  available_seat_service["total_amount"].to_f
+total_amount = (
+  BigDecimal(priced_offer.total_amount) + BigDecimal(available_seat_service["total_amount"])
+).to_f.to_s
 
 order = client.orders.create(params: {
   selected_offers: [priced_offer.id],

--- a/examples/book_with_seat.rb
+++ b/examples/book_with_seat.rb
@@ -61,7 +61,7 @@ puts "Adding seat #{available_seat['designator']} costing " \
 total_amount = (
   BigDecimal(priced_offer.total_amount) +
   BigDecimal(available_seat_service["total_amount"])
-).to_f.to_s
+).to_s("F")
 
 order = client.orders.create(params: {
   selected_offers: [priced_offer.id],

--- a/examples/search_and_book.rb
+++ b/examples/search_and_book.rb
@@ -50,7 +50,7 @@ puts "Adding an extra bag with service #{available_service['id']}, " \
 
 total_amount = (
   BigDecimal(priced_offer.total_amount) + BigDecimal(available_service["total_amount"])
-).to_f.to_s
+).to_s("F")
 
 order = client.orders.create(params: {
   selected_offers: [priced_offer.id],

--- a/examples/search_and_book.rb
+++ b/examples/search_and_book.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "duffel_api"
+require "bigdecimal"
 
 client = DuffelAPI::Client.new(
   access_token: ENV["DUFFEL_ACCESS_TOKEN"],
@@ -47,7 +48,9 @@ available_service = priced_offer.available_services.first
 puts "Adding an extra bag with service #{available_service['id']}, " \
      "costing #{available_service['total_amount']} #{available_service['total_currency']}"
 
-total_amount = priced_offer.total_amount.to_f + available_service["total_amount"].to_f
+total_amount = (
+  BigDecimal(priced_offer.total_amount) + BigDecimal(available_service["total_amount"])
+).to_f.to_s
 
 order = client.orders.create(params: {
   selected_offers: [priced_offer.id],


### PR DESCRIPTION
💁 Ruby provides built-in support for arbitrary precision integer arithmetic. This is often not sufficient for correctly calculating pricing arithmetic. `BigDecimal` provides similar support for very large or very accurate floating point numbers and is available in the Ruby standard library.

An example of a potential rounding error which could occur, one using
the existing method and the other using `BigDecimal`, follows:

```ruby
irb(main):001:0> "145.65".to_f + "37.77".to_f
=> 183.42000000000002
irb(main):002:0> require 'bigdecimal'
=> true
irb(main):003:0> (BigDecimal("145.65") + BigDecimal("37.77")).to_f
=> 183.42
irb(main):004:0> (BigDecimal("145.65") + BigDecimal("37.77")).to_f.to_s
=> "183.42"
```

This is demonstrated in practise via one of the existing example files which I have subsequently updated to use `BigDecimal`.
```
Created offer request: orq_0000AGIwEFhIrv0eFe6YfQ
Got 1 offers
Selected offer off_0000AGIwEFtM96eOr1kBSE to book
The initial price for offer off_0000AGIwEFtM96eOr1kBSE is 135.65 AUD
The final price for offer off_0000AGIwEFtM96eOr1kBSE is 145.65 AUD
Adding an extra bag with service ase_0000AGIwEUp1SNVTFk9PwP, costing 37.77 AUD
Paying a total amount of 183.42000000000002
Paying a total amount of 183.42
```