### PR TITLE
Auto-paginate offers 200 at a time with `OffersService#all`

### DIFF
--- a/lib/duffel_api/services/base_service.rb
+++ b/lib/duffel_api/services/base_service.rb
@@ -7,6 +7,9 @@ module DuffelAPI
     class BaseService
       extend Forwardable
 
+      # Default params to use with the auto-paginating `#all` method
+      DEFAULT_ALL_PARAMS = { limit: 200 }.freeze
+
       # Sets up a resource-specific service based on an API service
       #
       # @param api_service [APIService]

--- a/lib/duffel_api/services/offers_service.rb
+++ b/lib/duffel_api/services/offers_service.rb
@@ -22,7 +22,7 @@ module DuffelAPI
       end
 
       # Returns an `Enumerator` which can automatically cycle through multiple
-      # pages of `Resources;:Offers`s.
+      # pages of `Resources::Offers`s.
       #
       # By default, this will use pages of 200 results under the hood, but this
       # can be customised by specifying the `:limit` option in the `:params`.

--- a/lib/duffel_api/services/offers_service.rb
+++ b/lib/duffel_api/services/offers_service.rb
@@ -22,13 +22,19 @@ module DuffelAPI
       end
 
       # Returns an `Enumerator` which can automatically cycle through multiple
-      # pages of `Resources;:Offers`s
+      # pages of `Resources;:Offers`s.
+      #
+      # By default, this will use pages of 200 results under the hood, but this
+      # can be customised by specifying the `:limit` option in the `:params`.
       #
       # @param options [Hash] options passed to `#list`, for example `:params` to
       #   send an HTTP querystring with filters
       # @return [Enumerator]
       # @raise [Errors::Error] when the Duffel API returns an error
       def all(options = {})
+        options[:params] ||= {}
+        options[:params] = DEFAULT_ALL_PARAMS.merge(options[:params])
+
         Paginator.new(
           service: self,
           options: options,

--- a/spec/duffel_api/services/offers_service_spec.rb
+++ b/spec/duffel_api/services/offers_service_spec.rb
@@ -102,33 +102,37 @@ describe DuffelAPI::Services::OffersService do
   end
 
   describe "#all" do
-    let!(:first_response_stub) do
-      stub_request(:get, "https://api.duffel.com/air/offers").
-        with(query: { "offer_request_id" => "orq_0000AEdGRPso4CyykxEIsa" }).
-        to_return(
-          body: first_page_response_body,
-          headers: response_headers,
-        )
-    end
-
     let(:first_page_response_body) { load_fixture("offers/list.json") }
 
     let(:last_page_response_body) do
       convert_list_response_to_last_page(first_page_response_body)
     end
 
+    let!(:first_response_stub) do
+      stub_request(:get, "https://api.duffel.com/air/offers").
+        with(query: expected_query_params).
+        to_return(
+          body: first_page_response_body,
+          headers: response_headers,
+        )
+    end
+
     let!(:second_response_stub) do
       stub_request(:get, "https://api.duffel.com/air/offers").
-        with(query: { "after" => "g3QAAAABZAACaWRtAAAAGm9mZl8wMDAwQUVkR1Jra2lUVHpOVHdi" \
-                                 "ZGdj",
-                      "offer_request_id" => "orq_0000AEdGRPso4CyykxEIsa" }).
+        with(query: expected_query_params.merge(
+          "after" => "g3QAAAABZAACaWRtAAAAGm9mZl8wMDAwQUVkR1Jra2lUVHpOVHdiZGdj",
+        )).
         to_return(
           body: last_page_response_body,
           headers: response_headers,
         )
     end
 
-    it "automatically makes the extra requests to load all the pages" do
+    let(:expected_query_params) do
+      { limit: 200, offer_request_id: "orq_0000AEdGRPso4CyykxEIsa" }
+    end
+
+    it "automatically makes the requests to load all pages, 200 results at a time" do
       expect(
         client.offers.
           all(params: { offer_request_id: "orq_0000AEdGRPso4CyykxEIsa" }).
@@ -196,6 +200,21 @@ describe DuffelAPI::Services::OffersService do
       expect(api_response.headers).to eq(response_headers)
       expect(api_response.request_id).to eq(response_headers["x-request-id"])
       expect(api_response.status_code).to eq(200)
+    end
+
+    context "customising the limit per page" do
+      let(:expected_query_params) do
+        { limit: 33, offer_request_id: "orq_0000AEdGRPso4CyykxEIsa" }
+      end
+
+      it "requests the requested number of items per page from the API" do
+        client.offers.
+          all(params: { limit: 33, offer_request_id: "orq_0000AEdGRPso4CyykxEIsa" }).
+          to_a
+
+        expect(first_response_stub).to have_been_requested
+        expect(second_response_stub).to have_been_requested
+      end
     end
   end
 


### PR DESCRIPTION
For resources which can be listed, we offer two methods: `#list` (which gives you control over pagination as an integrator)
and `#all` (where the library paginates for you and returns an `Enumerator`).

This tweaks the behaviour of the auto-paginating `#all` method to paginate 200 records at a time by default - using `OffersService# all` as a proof of concept - rather than letting the API use its default (50 records).

This cuts the number of requests that you need to paginate through large result sets, reducing overall overhead. You can still override with your own custom `limit` if you prefer something else.

Once this PR is approved and merged, I plan to apply the same behaviour to other listable resources. But I want to start with one resource working first,