### PR TITLE
v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.3.0] - 2022-02-15
+
+- Automatically retry rate-limited requests (thanks to @ferrisoxide for the contribution!)
+- Paginate through records with `#all` 200 records at a time by default, rather than 50 records at a time
+
 ## [0.2.0] - 2022-01-11
 
 - Add `WebhookEvent.genuine?` for checking whether a webhook event was genuinely sent by Duffel

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A Ruby client library for the [Duffel API](https://duffel.com/docs/api).
 In most cases, you'll want to add `duffel_api` to your project as a dependency by listing it in your `Gemfile`, and then running `bundle`:
 
 ```ruby
-gem "duffel_api", "~> 0.2.0"
+gem "duffel_api", "~> 0.3.0"
 ```
 
 You can install `duffel_api` outside of the context of a project by running `gem install duffel_api` - for example if you want to play with the client library in `irb`.

--- a/lib/duffel_api/version.rb
+++ b/lib/duffel_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DuffelAPI
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
- Automatically retry rate-limited requests (thanks to @ferrisoxide for the contribution!)
- Paginate through records with `#all` 200 records at a time by default, rather than 50 records at a time