### PR TITLE
GitHub Actions workflow for publishing gem versions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,35 @@
+name: Publish Gem
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby-3.1
+          bundler-cache: true
+          bundler: default
+      - name: Check for RubyGems credentials
+        run: |
+          if [ -z "${RUBYGEMS_API_KEY}" ]; then
+            echo "Missing RUBYGEMS_API_KEY!"
+            exit 2
+          fi
+      - name: Configure RubyGems access
+        run: |
+          mkdir -p ~/.gem
+          touch ~/.gem/credentials
+          chmod 600 ~/.gem/credentials
+          echo ":rubygems_api_key: ${RUBYGEMS_API_KEY}" >> ~/.gem/credentials
+      - name: Build Ruby gem
+        run: gem build duffel_api.gemspec
+      - name: Publish Ruby gem
+        run: find . -name 'duffel_api-*.gem' -maxdepth 1 -exec gem push {} \;


### PR DESCRIPTION
💁 Building and pushing gems to RubyGems is tedious work but a small error while performing the steps involved can have unintended consequences. Using a GitHub Action to automate those steps should simplify the process of pushing new gems and enable anyone with the ability to push tags to this repository to trigger this workflow to run and publish a new gem version.