### PR TITLE
Move Code Examples to a different workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-
+    
 jobs:
   appraisal:
     name: Appraisal
@@ -27,40 +27,6 @@ jobs:
         run: bundle exec appraisal install
       - name: Run tests per Appraisal
         run: bundle exec appraisal rspec
-
-  code_examples:
-    name: Code Examples
-
-    runs-on: ubuntu-latest
-
-    needs: tests
-
-    env:
-      DUFFEL_ACCESS_TOKEN: ${{ secrets.DUFFEL_ACCESS_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: .downloaded-cache
-          key: downloaded-cache
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ruby-3.1
-          bundler-cache: true
-          bundler: default
-      - name: Run "search and book" example
-        run: bundle exec ruby examples/search_and_book.rb
-      - name: Run "hold and pay later" example
-        run: bundle exec ruby examples/hold_and_pay_later.rb
-      - name: Run "exploring data" example
-        run: bundle exec ruby examples/exploring_data.rb
-      - name: Run "book with extra baggage" example
-        run: bundle exec ruby examples/book_with_extra_baggage.rb
-      - name: Run "book with seat" example
-        run: bundle exec ruby examples/book_with_seat.rb
-      - name: Run "book and change" example
-        run: bundle exec ruby examples/book_and_change.rb
 
   coverage:
     name: Coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    
+
 jobs:
   appraisal:
     name: Appraisal

--- a/.github/workflows/code-examples.yaml
+++ b/.github/workflows/code-examples.yaml
@@ -3,6 +3,9 @@ name: Code Examples
 on:
   push:
     branches: [ main ]
+  schedule:
+    # daily:
+    - cron: '0 0 * * *'
 
 jobs:
   code_examples:

--- a/.github/workflows/code-examples.yaml
+++ b/.github/workflows/code-examples.yaml
@@ -1,0 +1,38 @@
+name: Code Examples
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  code_examples:
+    name: Code Examples
+
+    runs-on: ubuntu-latest
+
+    env:
+      DUFFEL_ACCESS_TOKEN: ${{ secrets.DUFFEL_ACCESS_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: .downloaded-cache
+          key: downloaded-cache
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby-3.1
+          bundler-cache: true
+          bundler: default
+      - name: Run "search and book" example
+        run: bundle exec ruby examples/search_and_book.rb
+      - name: Run "hold and pay later" example
+        run: bundle exec ruby examples/hold_and_pay_later.rb
+      - name: Run "exploring data" example
+        run: bundle exec ruby examples/exploring_data.rb
+      - name: Run "book with extra baggage" example
+        run: bundle exec ruby examples/book_with_extra_baggage.rb
+      - name: Run "book with seat" example
+        run: bundle exec ruby examples/book_with_seat.rb
+      - name: Run "book and change" example
+        run: bundle exec ruby examples/book_and_change.rb


### PR DESCRIPTION
Code Examples job always fails because it requires secrets that
are not available for external contributors. So the idea here is
move that job from the normal CI and only make it run on main. It
will simplify external contribution while keeping running the code
examples where it matters the most, on main.